### PR TITLE
Performance: side drawer cell selection

### DIFF
--- a/www/src/Theme.tsx
+++ b/www/src/Theme.tsx
@@ -6,6 +6,12 @@ import ClearIcon from "@material-ui/icons/Clear";
 const HEADING_TEXT = "Europa, sans-serif";
 const BODY_TEXT = '"Open Sans", sans-serif';
 
+declare module "@material-ui/core/styles/transitions" {
+  interface Easing {
+    custom: string;
+  }
+}
+
 const Theme = createMuiTheme({
   palette: {
     primary: { main: "#e22729" },
@@ -84,6 +90,11 @@ const Theme = createMuiTheme({
       fontWeight: "bold",
       letterSpacing: 0.25,
       lineHeight: 1.2,
+    },
+  },
+  transitions: {
+    easing: {
+      custom: "cubic-bezier(0.25, 0.1, 0.25, 1)",
     },
   },
   overrides: {

--- a/www/src/components/SideDrawer/Form/Autosave.tsx
+++ b/www/src/components/SideDrawer/Form/Autosave.tsx
@@ -18,7 +18,7 @@ export interface IAutosaveProps {
 
 export default function Autosave({ values, errors }: IAutosaveProps) {
   const { currentUser } = useAppContext();
-  const { tableState, selectedCell } = useFiretableContext();
+  const { tableState, sideDrawerRef } = useFiretableContext();
 
   const getEditables = value =>
     _pick(value, tableState?.columns?.map(c => c.key) ?? []);
@@ -27,7 +27,9 @@ export default function Autosave({ values, errors }: IAutosaveProps) {
     equalityFn: _isEqual,
   });
 
-  const row = selectedCell ? tableState?.rows[selectedCell.row] : {};
+  const row = sideDrawerRef?.current?.cell
+    ? tableState?.rows[sideDrawerRef?.current?.cell.row]
+    : {};
 
   useEffect(() => {
     if (!row || !row.ref) return;

--- a/www/src/components/SideDrawer/Form/index.tsx
+++ b/www/src/components/SideDrawer/Form/index.tsx
@@ -98,7 +98,7 @@ export default function Form({ fields, values }: IFormProps) {
 
     // Time out for double-clicking on cells, which can open the null editor
     setTimeout(() => elem?.scrollIntoView({ behavior: "smooth" }), 50);
-  }, [sideDrawerRef]);
+  }, [sideDrawerRef?.current]);
 
   return (
     <MuiPickersUtilsProvider utils={DateFnsUtils}>

--- a/www/src/components/SideDrawer/Form/index.tsx
+++ b/www/src/components/SideDrawer/Form/index.tsx
@@ -88,16 +88,17 @@ export interface IFormProps {
 export default function Form({ fields, values }: IFormProps) {
   const initialValues = getInitialValues(fields);
 
-  const { selectedCell } = useFiretableContext();
+  const { sideDrawerRef } = useFiretableContext();
   useEffect(() => {
-    if (!selectedCell?.column) return;
-    const elem = document.getElementById(
-      `sidedrawer-label-${selectedCell.column}`
-    )?.parentNode as HTMLElement;
+    const column = sideDrawerRef?.current?.cell?.column;
+    if (!column) return;
+
+    const elem = document.getElementById(`sidedrawer-label-${column}`)
+      ?.parentNode as HTMLElement;
 
     // Time out for double-clicking on cells, which can open the null editor
     setTimeout(() => elem?.scrollIntoView({ behavior: "smooth" }), 50);
-  }, [selectedCell?.column]);
+  }, [sideDrawerRef]);
 
   return (
     <MuiPickersUtilsProvider utils={DateFnsUtils}>

--- a/www/src/components/SideDrawer/index.tsx
+++ b/www/src/components/SideDrawer/index.tsx
@@ -32,7 +32,6 @@ export default function SideDrawer() {
 
   const [cell, setCell] = useState<SelectedCell>(null);
   const [open, setOpen] = useState(false);
-
   if (sideDrawerRef) sideDrawerRef.current = { cell, setCell, open, setOpen };
 
   const disabled = !cell || _isNil(cell.row);
@@ -52,6 +51,8 @@ export default function SideDrawer() {
     const idx = _findIndex(tableState?.columns, ["key", cell!.column]);
     dataGridRef?.current?.selectCell({ rowIdx: row, idx });
   };
+
+  const showBumpAnim = !open && cell?.column && cell?.row;
 
   // Map columns to form fields
   const fields = tableState?.columns?.map(column => {
@@ -110,7 +111,10 @@ export default function SideDrawer() {
         anchor="right"
         className={classes.drawer}
         classes={{
-          paperAnchorDockedRight: classes.paper,
+          paperAnchorDockedRight: clsx(
+            classes.paper,
+            showBumpAnim && classes.bumpPaper
+          ),
           paper: clsx({
             [classes.paperOpen]: open,
             [classes.paperClose]: !open,
@@ -163,7 +167,12 @@ export default function SideDrawer() {
         </div>
       )}
 
-      <div className={classes.drawerFabContainer}>
+      <div
+        className={clsx(
+          classes.drawerFabContainer,
+          showBumpAnim && classes.bumpDrawerFab
+        )}
+      >
         <Fab
           classes={{ root: classes.fab, disabled: classes.disabled }}
           color="secondary"

--- a/www/src/components/SideDrawer/index.tsx
+++ b/www/src/components/SideDrawer/index.tsx
@@ -52,8 +52,6 @@ export default function SideDrawer() {
     dataGridRef?.current?.selectCell({ rowIdx: row, idx });
   };
 
-  const showBumpAnim = !open && cell?.column && cell?.row;
-
   // Map columns to form fields
   const fields = tableState?.columns?.map(column => {
     const field: Field = {
@@ -113,7 +111,7 @@ export default function SideDrawer() {
         classes={{
           paperAnchorDockedRight: clsx(
             classes.paper,
-            showBumpAnim && classes.bumpPaper
+            !disabled && classes.bumpPaper
           ),
           paper: clsx({
             [classes.paperOpen]: open,
@@ -170,7 +168,7 @@ export default function SideDrawer() {
       <div
         className={clsx(
           classes.drawerFabContainer,
-          showBumpAnim && classes.bumpDrawerFab
+          !disabled && classes.bumpDrawerFab
         )}
       >
         <Fab

--- a/www/src/components/SideDrawer/index.tsx
+++ b/www/src/components/SideDrawer/index.tsx
@@ -126,32 +126,42 @@ export default function SideDrawer() {
         </ErrorBoundary>
       </Drawer>
 
-      <div className={classes.navFabContainer}>
-        <Fab
-          classes={{ root: classes.fab, disabled: classes.disabled }}
-          color="secondary"
-          size="small"
-          disabled={disabled || !cell || cell.row <= 0}
-          onClick={handleNavigate("up")}
-        >
-          <ChevronUpIcon />
-        </Fab>
+      {open && (
+        <div className={classes.navFabContainer}>
+          <Fab
+            classes={{
+              root: clsx(classes.fab, classes.navFab),
+              disabled: classes.disabled,
+            }}
+            style={{ animationDelay: "0.2s" }}
+            color="secondary"
+            size="small"
+            disabled={disabled || !cell || cell.row <= 0}
+            onClick={handleNavigate("up")}
+          >
+            <ChevronUpIcon />
+          </Fab>
 
-        <Fab
-          classes={{ root: classes.fab, disabled: classes.disabled }}
-          color="secondary"
-          size="small"
-          disabled={
-            disabled ||
-            !tableState ||
-            !cell ||
-            cell.row >= tableState.rows.length - 1
-          }
-          onClick={handleNavigate("down")}
-        >
-          <ChevronDownIcon />
-        </Fab>
-      </div>
+          <Fab
+            classes={{
+              root: clsx(classes.fab, classes.navFab),
+              disabled: classes.disabled,
+            }}
+            style={{ animationDelay: "0.1s" }}
+            color="secondary"
+            size="small"
+            disabled={
+              disabled ||
+              !tableState ||
+              !cell ||
+              cell.row >= tableState.rows.length - 1
+            }
+            onClick={handleNavigate("down")}
+          >
+            <ChevronDownIcon />
+          </Fab>
+        </div>
+      )}
 
       <div className={classes.drawerFabContainer}>
         <Fab

--- a/www/src/components/SideDrawer/index.tsx
+++ b/www/src/components/SideDrawer/index.tsx
@@ -18,18 +18,24 @@ import { FieldType } from "constants/fields";
 export const DRAWER_WIDTH = 600;
 export const DRAWER_COLLAPSED_WIDTH = 36;
 
+type SelectedCell = { row: number; column: string } | null;
+export type SideDrawerRef = {
+  cell: SelectedCell;
+  setCell: React.Dispatch<React.SetStateAction<SelectedCell>>;
+  open: boolean;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
+};
+
 export default function SideDrawer() {
   const classes = useStyles();
-  const {
-    tableState,
-    selectedCell,
-    setSelectedCell,
-    sideDrawerOpen: open,
-    setSideDrawerOpen: setOpen,
-    dataGridRef,
-  } = useFiretableContext();
+  const { tableState, dataGridRef, sideDrawerRef } = useFiretableContext();
 
-  const disabled = !selectedCell || _isNil(selectedCell.row);
+  const [cell, setCell] = useState<SelectedCell>(null);
+  const [open, setOpen] = useState(false);
+
+  if (sideDrawerRef) sideDrawerRef.current = { cell, setCell, open, setOpen };
+
+  const disabled = !cell || _isNil(cell.row);
   useEffect(() => {
     if (disabled && setOpen) setOpen(false);
   }, [disabled]);
@@ -37,13 +43,13 @@ export default function SideDrawer() {
   const handleNavigate = (direction: "up" | "down") => () => {
     if (!tableState?.rows) return;
 
-    let row = selectedCell!.row;
+    let row = cell!.row;
     if (direction === "up" && row > 0) row -= 1;
     if (direction === "down" && row < tableState.rows.length - 1) row += 1;
 
-    setSelectedCell!(cell => ({ ...cell, row }));
+    setCell!(cell => ({ column: cell!.column, row }));
 
-    const idx = _findIndex(tableState?.columns, ["key", selectedCell!.column]);
+    const idx = _findIndex(tableState?.columns, ["key", cell!.column]);
     dataGridRef?.current?.selectCell({ rowIdx: row, idx });
   };
 
@@ -113,11 +119,8 @@ export default function SideDrawer() {
       >
         <ErrorBoundary>
           <div className={classes.drawerContents}>
-            {open && fields && selectedCell && (
-              <Form
-                fields={fields}
-                values={tableState?.rows[selectedCell.row] ?? {}}
-              />
+            {open && fields && cell && (
+              <Form fields={fields} values={tableState?.rows[cell.row] ?? {}} />
             )}
           </div>
         </ErrorBoundary>
@@ -128,7 +131,7 @@ export default function SideDrawer() {
           classes={{ root: classes.fab, disabled: classes.disabled }}
           color="secondary"
           size="small"
-          disabled={disabled || !selectedCell || selectedCell.row <= 0}
+          disabled={disabled || !cell || cell.row <= 0}
           onClick={handleNavigate("up")}
         >
           <ChevronUpIcon />
@@ -141,8 +144,8 @@ export default function SideDrawer() {
           disabled={
             disabled ||
             !tableState ||
-            !selectedCell ||
-            selectedCell.row >= tableState.rows.length - 1
+            !cell ||
+            cell.row >= tableState.rows.length - 1
           }
           onClick={handleNavigate("down")}
         >

--- a/www/src/components/SideDrawer/useStyles.ts
+++ b/www/src/components/SideDrawer/useStyles.ts
@@ -23,13 +23,13 @@ export const useStyles = makeStyles(theme =>
     },
     paperOpen: {
       transition: theme.transitions.create("transform", {
-        easing: theme.transitions.easing.sharp,
+        easing: theme.transitions.easing.custom,
         duration: theme.transitions.duration.enteringScreen,
       }),
     },
     paperClose: {
       transition: theme.transitions.create("transform", {
-        easing: theme.transitions.easing.sharp,
+        easing: theme.transitions.easing.custom,
         duration: theme.transitions.duration.leavingScreen,
       }),
 
@@ -51,18 +51,15 @@ export const useStyles = makeStyles(theme =>
     navFabContainer: {
       position: "absolute",
       top: theme.spacing(8),
-      right: theme.spacing(2),
+      right: DRAWER_WIDTH - 20,
       zIndex: theme.zIndex.drawer + 1,
-
-      transition: theme.transitions.create("transform", {
-        easing: theme.transitions.easing.sharp,
-        duration: theme.transitions.duration.enteringScreen,
-      }),
-
-      "$open &": {
-        transform: `translate(-${DRAWER_WIDTH - DRAWER_COLLAPSED_WIDTH}px)`,
-        transitionDuration: `${theme.transitions.duration.leavingScreen}ms`,
-      },
+    },
+    "@keyframes navFab": {
+      from: { transform: "translateY(-50vh)" },
+      to: { transform: "translateY(0)" },
+    },
+    navFab: {
+      animation: `${theme.transitions.duration.standard}ms $navFab both`,
     },
 
     drawerFabContainer: {
@@ -73,7 +70,7 @@ export const useStyles = makeStyles(theme =>
       zIndex: theme.zIndex.drawer + 1,
 
       transition: theme.transitions.create("transform", {
-        easing: theme.transitions.easing.sharp,
+        easing: theme.transitions.easing.custom,
         duration: theme.transitions.duration.enteringScreen,
       }),
 
@@ -88,19 +85,9 @@ export const useStyles = makeStyles(theme =>
       width: "2em",
       height: "2em",
 
-      // transition: theme.transitions.create("transform", {
-      //   easing: theme.transitions.easing.sharp,
-      //   duration: theme.transitions.duration.enteringScreen,
-      // }),
-
-      "$open &": {
-        transform: "rotate(180deg)",
-        //   transitionDuration: `${theme.transitions.duration.leavingScreen}ms`,
-      },
+      "$open &": { transform: "rotate(180deg)" },
     },
 
-    drawerContents: {
-      padding: theme.spacing(8),
-    },
+    drawerContents: { padding: theme.spacing(8) },
   })
 );

--- a/www/src/components/SideDrawer/useStyles.ts
+++ b/www/src/components/SideDrawer/useStyles.ts
@@ -88,14 +88,14 @@ export const useStyles = makeStyles(theme =>
       width: "2em",
       height: "2em",
 
-      transition: theme.transitions.create("transform", {
-        easing: theme.transitions.easing.sharp,
-        duration: theme.transitions.duration.enteringScreen,
-      }),
+      // transition: theme.transitions.create("transform", {
+      //   easing: theme.transitions.easing.sharp,
+      //   duration: theme.transitions.duration.enteringScreen,
+      // }),
 
       "$open &": {
         transform: "rotate(180deg)",
-        transitionDuration: `${theme.transitions.duration.leavingScreen}ms`,
+        //   transitionDuration: `${theme.transitions.duration.leavingScreen}ms`,
       },
     },
 

--- a/www/src/components/SideDrawer/useStyles.ts
+++ b/www/src/components/SideDrawer/useStyles.ts
@@ -37,6 +37,23 @@ export const useStyles = makeStyles(theme =>
       transform: `translateX(${DRAWER_WIDTH - DRAWER_COLLAPSED_WIDTH}px)`,
     },
 
+    "@keyframes bumpPaper": {
+      "0%": {
+        transform: `translateX(${DRAWER_WIDTH - DRAWER_COLLAPSED_WIDTH}px)`,
+      },
+      "50%": {
+        transform: `translateX(${DRAWER_WIDTH -
+          DRAWER_COLLAPSED_WIDTH -
+          theme.spacing(4)}px)`,
+      },
+      "100%": {
+        transform: `translateX(${DRAWER_WIDTH - DRAWER_COLLAPSED_WIDTH}px)`,
+      },
+    },
+    bumpPaper: {
+      animation: `${theme.transitions.duration.standard}ms ${theme.transitions.easing.custom} both $bumpPaper`,
+    },
+
     fab: {
       display: "flex",
 
@@ -59,7 +76,7 @@ export const useStyles = makeStyles(theme =>
       to: { transform: "translateY(0)" },
     },
     navFab: {
-      animation: `${theme.transitions.duration.standard}ms $navFab both`,
+      animation: `${theme.transitions.duration.standard}ms ${theme.transitions.easing.custom} both $navFab`,
     },
 
     drawerFabContainer: {
@@ -86,6 +103,15 @@ export const useStyles = makeStyles(theme =>
       height: "2em",
 
       "$open &": { transform: "rotate(180deg)" },
+    },
+
+    "@keyframes bumpDrawerFab": {
+      "0%": { transform: `translate(0px, -50%)` },
+      "50%": { transform: `translate(${-theme.spacing(4)}px, -50%)` },
+      "100%": { transform: `translate(0px, -50%)` },
+    },
+    bumpDrawerFab: {
+      animation: `${theme.transitions.duration.standard}ms ${theme.transitions.easing.custom} both $bumpDrawerFab`,
     },
 
     drawerContents: { padding: theme.spacing(8) },

--- a/www/src/components/SideDrawer/useStyles.ts
+++ b/www/src/components/SideDrawer/useStyles.ts
@@ -51,7 +51,7 @@ export const useStyles = makeStyles(theme =>
       },
     },
     bumpPaper: {
-      animation: `${theme.transitions.duration.standard}ms ${theme.transitions.easing.custom} both $bumpPaper`,
+      animation: `${theme.transitions.duration.standard}ms ${theme.transitions.easing.custom} $bumpPaper`,
     },
 
     fab: {
@@ -111,7 +111,7 @@ export const useStyles = makeStyles(theme =>
       "100%": { transform: `translate(0px, -50%)` },
     },
     bumpDrawerFab: {
-      animation: `${theme.transitions.duration.standard}ms ${theme.transitions.easing.custom} both $bumpDrawerFab`,
+      animation: `${theme.transitions.duration.standard}ms ${theme.transitions.easing.custom} $bumpDrawerFab`,
     },
 
     drawerContents: { padding: theme.spacing(8) },

--- a/www/src/components/Table/editors/SideDrawerEditor.tsx
+++ b/www/src/components/Table/editors/SideDrawerEditor.tsx
@@ -20,11 +20,12 @@ function SideDrawerEditor_(props: EditorProps<any, any>) {
   useStyles();
 
   const { column, rowData } = props;
-  const { sideDrawerOpen, setSideDrawerOpen } = useFiretableContext();
+  const { sideDrawerRef } = useFiretableContext();
 
   useEffect(() => {
-    if (!sideDrawerOpen) setSideDrawerOpen!(true);
-  }, [column?.key, rowData?.id]);
+    if (!sideDrawerRef?.current?.open && sideDrawerRef?.current?.setOpen)
+      sideDrawerRef?.current?.setOpen(true);
+  }, [column, rowData]);
 
   return null;
 }

--- a/www/src/components/Table/formatters/withCustomCell.tsx
+++ b/www/src/components/Table/formatters/withCustomCell.tsx
@@ -42,7 +42,7 @@ const withCustomCell = (Component: React.ComponentType<CustomCellProps>) => (
   props: FormatterProps<any>
 ) => {
   const classes = useStyles();
-  const { updateCell, selectedCell } = useFiretableContext();
+  const { updateCell, sideDrawerRef } = useFiretableContext();
 
   const handleSubmit = (value: any) => {
     if (updateCell)
@@ -50,8 +50,8 @@ const withCustomCell = (Component: React.ComponentType<CustomCellProps>) => (
   };
 
   const isSelected =
-    selectedCell?.row === props.rowIdx &&
-    selectedCell?.column === (props.column.key as string);
+    sideDrawerRef?.current?.cell?.row === props.rowIdx &&
+    sideDrawerRef?.current?.cell?.column === (props.column.key as string);
 
   return (
     <ErrorBoundary fullScreen={false} basic>

--- a/www/src/components/Table/index.tsx
+++ b/www/src/components/Table/index.tsx
@@ -31,7 +31,7 @@ import { DRAWER_WIDTH, DRAWER_COLLAPSED_WIDTH } from "components/SideDrawer";
 import { APP_BAR_HEIGHT } from "components/Navigation";
 import useStyles from "./styles";
 
-const Hotkeys = lazy(() => import("./HotKeys"));
+// const Hotkeys = lazy(() => import("./HotKeys"));
 const ColumnEditor = lazy(() => import("./ColumnEditor/index"));
 const { DraggableContainer } = DraggableHeader;
 
@@ -54,18 +54,16 @@ export default function Table({ collection, filters }: ITableProps) {
   const {
     tableState,
     tableActions,
-    selectedCell,
-    setSelectedCell,
     updateCell,
-    sideDrawerOpen,
     dataGridRef,
+    sideDrawerRef,
   } = useFiretableContext();
 
   useEffect(() => {
     if (tableActions && tableState && tableState.tablePath !== collection) {
       console.log("setting table");
       tableActions.table.set(collection, filters);
-      setSelectedCell!({});
+      if (sideDrawerRef?.current) sideDrawerRef.current.setCell!(null);
     }
   }, [collection]);
 
@@ -134,15 +132,16 @@ export default function Table({ collection, filters }: ITableProps) {
   const inSubTable = collection.split("/").length > 1;
 
   let tableWidth: any = `calc(100% - ${
-    sideDrawerOpen ? DRAWER_WIDTH : DRAWER_COLLAPSED_WIDTH
+    DRAWER_COLLAPSED_WIDTH
+    // sideDrawerOpen ? DRAWER_WIDTH : DRAWER_COLLAPSED_WIDTH
   }px)`;
   if (windowSize.width < theme.breakpoints.values.md) tableWidth = "100%";
 
   return (
     <>
-      <Suspense fallback={<Loading message="Loading header" />}>
+      {/* <Suspense fallback={<Loading message="Loading header" />}>
         <Hotkeys selectedCell={selectedCell} />
-      </Suspense>
+      </Suspense> */}
 
       {inSubTable && <SubTableBreadcrumbs collection={collection} />}
 
@@ -186,7 +185,10 @@ export default function Table({ collection, filters }: ITableProps) {
             onCellSelected={({ rowIdx, idx: colIdx }) => {
               // Prevent selecting final row
               if (colIdx < columns.length - 1)
-                setSelectedCell!({ row: rowIdx, column: columns[colIdx].key });
+                sideDrawerRef?.current?.setCell!({
+                  row: rowIdx,
+                  column: columns[colIdx].key as string,
+                });
             }}
             enableCellSelect
             onScroll={handleScroll}

--- a/www/src/contexts/firetableContext.tsx
+++ b/www/src/contexts/firetableContext.tsx
@@ -10,6 +10,7 @@ import useFiretable, {
 } from "hooks/useFiretable";
 import useSettings from "hooks/useSettings";
 import { useAppContext } from "./appContext";
+import { SideDrawerRef } from "components/SideDrawer";
 
 type SelectedColumnHeader = {
   column: Column<any> & { [key: string]: any };
@@ -36,13 +37,9 @@ interface FiretableContextProps {
     value: any
   ) => void;
   createTable: Function;
-  selectedCell: { row: number; column: string };
-  setSelectedCell: Function;
   userClaims: any;
 
-  sideDrawerOpen: boolean;
-  setSideDrawerOpen: React.Dispatch<React.SetStateAction<boolean>>;
-
+  // TODO: Investigate if this can be moved out of this context
   selectedColumnHeader: SelectedColumnHeader | null;
   setSelectedColumnHeader: React.Dispatch<
     React.SetStateAction<SelectedColumnHeader | null>
@@ -50,6 +47,8 @@ interface FiretableContextProps {
 
   // A ref to the data grid. Contains data grid functions
   dataGridRef: React.RefObject<DataGridHandle>;
+  // A ref to the side drawer state. Prevents unnecessary re-renders
+  sideDrawerRef: React.MutableRefObject<SideDrawerRef | undefined>;
 }
 
 const firetableContext = React.createContext<Partial<FiretableContextProps>>(
@@ -61,16 +60,11 @@ export const useFiretableContext = () => useContext(firetableContext);
 
 export const FiretableContextProvider: React.FC = ({ children }) => {
   const { tableState, tableActions } = useFiretable();
-  const [selectedCell, setSelectedCell] = useState<{
-    row: number;
-    column: string;
-  }>();
   const [tables, setTables] = useState<FiretableContextProps["tables"]>();
   const [sections, setSections] = useState<FiretableContextProps["sections"]>();
   const [settings, createTable] = useSettings();
   const [userRoles, setUserRoles] = useState<null | string[]>();
   const [userClaims, setUserClaims] = useState<any>();
-  const [sideDrawerOpen, setSideDrawerOpen] = useState<boolean>(false);
   const [
     selectedColumnHeader,
     setSelectedColumnHeader,
@@ -122,24 +116,22 @@ export const FiretableContextProvider: React.FC = ({ children }) => {
 
   // A ref to the data grid. Contains data grid functions
   const dataGridRef = useRef<DataGridHandle>(null);
+  const sideDrawerRef = useRef<SideDrawerRef>();
 
   return (
     <firetableContext.Provider
       value={{
         tableState,
         tableActions,
-        selectedCell,
-        setSelectedCell,
         updateCell,
         createTable,
         tables,
         sections,
         userClaims,
-        sideDrawerOpen,
-        setSideDrawerOpen,
         selectedColumnHeader,
         setSelectedColumnHeader,
         dataGridRef,
+        sideDrawerRef,
       }}
     >
       {children}


### PR DESCRIPTION
Fixes slow cell selection due to side drawer state being stored in firetableContext.
firetableContext now stores a ref to side drawer’s state to be able to update the selected cell and open/close the drawer from anywhere in the app

Also improves animations in side drawer