### PR TITLE
update helper text in create table form

### DIFF
--- a/www/src/components/TableSettings/form.tsx
+++ b/www/src/components/TableSettings/form.tsx
@@ -118,7 +118,7 @@ export const tableSettings = (
     type: FIELDS.description,
     description: (
       <HelperText>
-        Choose which users have access to this table. Remember to set the
+        Choose which roles have access to this table. Remember to set the
         appropriate Firestore Security Rules for the “
         <span style={{ fontFamily: MONO_FONT }}>{values.collection}</span>”
         collection.


### PR DESCRIPTION
Hello, I am setting up Firetable for the first time and I was cracking my head around why my tables are not visible in the side menu. I think that the helper text is misleading as I was passing user email instead of role to this field. 

I propose to change `users` to `roles` which is more appropriate.