### PR TITLE
add force refresh derivatives/sparks to table header

### DIFF
--- a/www/src/components/Table/TableHeader/ForceRefresh.tsx
+++ b/www/src/components/Table/TableHeader/ForceRefresh.tsx
@@ -1,0 +1,97 @@
+import React, { useState } from "react";
+
+import TableHeaderButton from "./TableHeaderButton";
+import LoopIcon from "@material-ui/icons/Loop";
+
+import { useFiretableContext } from "contexts/FiretableContext";
+import { db } from "../../../firebase";
+import { isCollectionGroup } from "utils/fns";
+import CircularProgress from "@material-ui/core/CircularProgress";
+
+import _camelCase from "lodash/camelCase";
+import _get from "lodash/get";
+import _find from "lodash/find";
+import _sortBy from "lodash/sortBy";
+
+import { makeStyles, createStyles, DialogContentText } from "@material-ui/core";
+
+import Modal from "components/Modal";
+
+const useStyles = makeStyles((theme) =>
+  createStyles({
+    paper: {
+      [theme.breakpoints.up("sm")]: {
+        maxWidth: 500,
+      },
+    },
+    spinner: { marginRight: theme.spacing(1) },
+  })
+);
+
+export default function TableSettings() {
+  const classes = useStyles();
+  const [open, setOpen] = useState(false);
+  const [updating, setUpdating] = useState(false);
+  const handleClose = () => {
+    setOpen(false);
+  };
+  const { tableState } = useFiretableContext();
+
+  const query: any = isCollectionGroup()
+    ? db.collectionGroup(tableState?.tablePath!)
+    : db.collection(tableState?.tablePath!);
+
+  const handleConfirm = async () => {
+    setUpdating(true);
+    const _ft_forcedUpdateAt = new Date();
+
+    const batch = db.batch();
+    const querySnapshot = await query.get();
+    querySnapshot.docs.forEach((doc) => {
+      batch.update(doc.ref, { _ft_forcedUpdateAt });
+    });
+    await batch.commit();
+    setUpdating(false);
+    setOpen(false);
+  };
+
+  return (
+    <>
+      <TableHeaderButton
+        title="Force Refresh"
+        onClick={() => setOpen(true)}
+        icon={<LoopIcon />}
+      />
+
+      {open && (
+        <Modal
+          onClose={handleClose}
+          classes={{ paper: classes.paper }}
+          title={"Confirm Force Refresh"}
+          header={
+            <>
+              <DialogContentText>
+                Are you sure you want to force a refresh of all Sparks and
+                Derivatives?
+              </DialogContentText>
+            </>
+          }
+          actions={{
+            primary: {
+              children: "Confirm",
+              onClick: handleConfirm,
+              startIcon: updating && (
+                <CircularProgress className={classes.spinner} size={16} />
+              ),
+              disabled: updating,
+            },
+            secondary: {
+              children: "Cancel",
+              onClick: handleClose,
+            },
+          }}
+        ></Modal>
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
Add a force refresh button to update the _ft_forcedUpdateAt time for all documents in a collection resulting in the sparks (and derivatives when combined with my previous push) refreshing for all documents.

Force refresh button will be hidden if the user is not admin or the table contains no sparks or derivatives

Example:
**Step 1: Adding a new derivative:**
https://www.loom.com/share/8f5289495a074217a9d384bceff569e1

**Step 2: Force Refresh:**
https://www.loom.com/share/e1f831bdb3ba43dbb5fc398e2a1e3336